### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "csharp"
+run = "Mono C# compiler version 4.6.2.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![NoteBook FanControl](https://github.com/hirschmann/nbfc/wiki/images/banner.png)
-
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/nbfc)](https://repl.it/github/UzayAnil/nbfc)
 NBFC is a cross-platform fan control service for notebooks.
 It comes with a powerful configuration system, which allows to adjust it to many different notebook models.
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@UzayAnil/nbfc-1).